### PR TITLE
Cascade NIP-47/XX units clarification (_sats suffix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,7 +1875,7 @@ checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
 [[package]]
 name = "nostr"
 version = "0.44.1"
-source = "git+https://github.com/dukeh3/nostr.git?rev=9ac9adc2#9ac9adc2fbd8cbdb0767d22f26b183d65bba71f4"
+source = "git+https://github.com/dukeh3/nostr.git?rev=247df9c1#247df9c114931e239c8bd7c8179cca21827136d0"
 dependencies = [
  "aes",
  "base64 0.22.1",
@@ -1900,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "nostr-database"
 version = "0.44.0"
-source = "git+https://github.com/dukeh3/nostr.git?rev=9ac9adc2#9ac9adc2fbd8cbdb0767d22f26b183d65bba71f4"
+source = "git+https://github.com/dukeh3/nostr.git?rev=247df9c1#247df9c114931e239c8bd7c8179cca21827136d0"
 dependencies = [
  "btreecap",
  "lru",
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "nostr-gossip"
 version = "0.44.0"
-source = "git+https://github.com/dukeh3/nostr.git?rev=9ac9adc2#9ac9adc2fbd8cbdb0767d22f26b183d65bba71f4"
+source = "git+https://github.com/dukeh3/nostr.git?rev=247df9c1#247df9c114931e239c8bd7c8179cca21827136d0"
 dependencies = [
  "nostr",
 ]
@@ -1919,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "nostr-sdk"
 version = "0.44.1"
-source = "git+https://github.com/dukeh3/nostr.git?rev=9ac9adc2#9ac9adc2fbd8cbdb0767d22f26b183d65bba71f4"
+source = "git+https://github.com/dukeh3/nostr.git?rev=247df9c1#247df9c114931e239c8bd7c8179cca21827136d0"
 dependencies = [
  "async-utility",
  "async-wsocket",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "nwc"
 version = "0.44.0"
-source = "git+https://github.com/dukeh3/nostr.git?rev=9ac9adc2#9ac9adc2fbd8cbdb0767d22f26b183d65bba71f4"
+source = "git+https://github.com/dukeh3/nostr.git?rev=247df9c1#247df9c114931e239c8bd7c8179cca21827136d0"
 dependencies = [
  "nostr",
  "nostr-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
-nostr-sdk = { git = "https://github.com/dukeh3/nostr.git", rev = "9ac9adc2" }
-nwc = { git = "https://github.com/dukeh3/nostr.git", rev = "9ac9adc2" }
+nostr-sdk = { git = "https://github.com/dukeh3/nostr.git", rev = "247df9c1" }
+nwc = { git = "https://github.com/dukeh3/nostr.git", rev = "247df9c1" }
 bip321 = { git = "https://github.com/DarkWebDivingClub/bip321.git", rev = "fcd4864" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -654,7 +654,9 @@ struct OpenChannelParams {
     pubkey: String,
     #[serde(default)]
     host: Option<String>,
-    amount: u64,
+    /// Channel capacity in sats (NIP-XX `_sats` rule — on-chain funding output).
+    amount_sats: u64,
+    /// Amount to push to peer, in msats (NIP-XX — Lightning channel state).
     #[serde(default)]
     push_amount: Option<u64>,
     #[serde(default)]
@@ -2673,13 +2675,13 @@ fn process_control_request(request: ControlRequest, caller_pubkey: &str) -> Cont
                 };
             }
         };
-        if params.amount == 0 {
+        if params.amount_sats == 0 {
             return ControlResponse {
                 result_type: "open_channel".to_string(),
                 result: None,
                 error: Some(control_error(
                     "OTHER",
-                    "amount must be greater than 0".to_string(),
+                    "amount_sats must be greater than 0".to_string(),
                 )),
             };
         }
@@ -2694,7 +2696,9 @@ fn process_control_request(request: ControlRequest, caller_pubkey: &str) -> Cont
             };
         };
 
-        let push_msat = params.push_amount.map(|sats| sats * 1000);
+        // Per NIP-XX (post units patch): push_amount is already msats on the wire.
+        // No unit conversion needed before calling ldk-node.
+        let push_msat = params.push_amount;
         let address = if let Some(ref host) = params.host {
             host.clone()
         } else {
@@ -2720,7 +2724,7 @@ fn process_control_request(request: ControlRequest, caller_pubkey: &str) -> Cont
         if let Err(e) = ldk_service.open_channel(
             &params.pubkey,
             &address,
-            params.amount,
+            params.amount_sats,
             push_msat,
         ) {
             return ControlResponse {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,7 +520,7 @@ fn request_spend_msat(request: &Request) -> Option<u64> {
     match &request.params {
         RequestParams::PayInvoice(params) => params.amount,
         RequestParams::PayKeysend(params) => Some(params.amount),
-        RequestParams::PayOnchain(params) => Some(params.amount.saturating_mul(1000)),
+        RequestParams::PayOnchain(params) => Some(params.amount_sats.saturating_mul(1000)),
         RequestParams::PayOffer(params) => params.amount,
         RequestParams::PayBip321(params) => {
             bip321::Uri::parse(&params.uri)
@@ -1045,7 +1045,8 @@ impl Handler for GetBalanceHandler {
             result: Some(ResponseResult::GetBalance(GetBalanceResponse {
                 balance: bal.total_msat,
                 lightning_balance: Some(bal.lightning_msat),
-                onchain_balance: Some(bal.onchain_msat),
+                // On-chain UTXO sum is sat-precise; divide by 1000 to match spec _sats convention.
+                onchain_balance_sats: Some(bal.onchain_msat / 1000),
             })),
         })
     }
@@ -1514,10 +1515,10 @@ impl Handler for PayOnchainHandler {
                     message: "address is required".to_string(),
                 });
             }
-            if params.amount == 0 {
+            if params.amount_sats == 0 {
                 return Err(NIP47Error {
                     code: ErrorCode::Other,
-                    message: "amount must be greater than 0".to_string(),
+                    message: "amount_sats must be greater than 0".to_string(),
                 });
             }
             return Ok(());
@@ -1537,7 +1538,7 @@ impl Handler for PayOnchainHandler {
 
         if let RequestParams::PayOnchain(params) = &req.params {
             let txid = ldk_service
-                .pay_onchain(&params.address, params.amount, params.feerate)
+                .pay_onchain(&params.address, params.amount_sats, params.feerate)
                 .map_err(|e| map_ldk_service_error("pay_onchain", ErrorCode::PaymentFailed, e))?;
 
             return Ok(Response {
@@ -1743,19 +1744,19 @@ impl Handler for LookupAddressHandler {
                 .iter()
                 .map(|tx| AddressTransaction {
                     txid: tx.txid.clone(),
-                    amount: tx.amount_sats,
+                    amount_sats: tx.amount_sats,
                     timestamp: Timestamp::from(tx.timestamp),
                 })
                 .collect();
 
-            let total_received: u64 = record.transactions.iter().map(|tx| tx.amount_sats).sum();
+            let total_received_sats: u64 = record.transactions.iter().map(|tx| tx.amount_sats).sum();
 
             return Ok(Response {
                 result_type: Method::LookupAddress,
                 error: None,
                 result: Some(ResponseResult::LookupAddress(LookupAddressResponse {
                     address: record.address,
-                    total_received,
+                    total_received_sats,
                     transactions,
                 })),
             });
@@ -1994,11 +1995,11 @@ impl Handler for ListAddressesHandler {
             let mut addresses: Vec<AddressEntry> = address_store::list_addresses()
                 .iter()
                 .map(|record| {
-                    let total_received: u64 =
+                    let total_received_sats: u64 =
                         record.transactions.iter().map(|tx| tx.amount_sats).sum();
                     AddressEntry {
                         address: record.address.clone(),
-                        total_received,
+                        total_received_sats,
                     }
                 })
                 .collect();

--- a/tests/control_channel_payments_scenario.rs
+++ b/tests/control_channel_payments_scenario.rs
@@ -189,8 +189,8 @@ async fn alice_opens_channel_then_both_directions_pay() -> Result<()> {
             "params": {
                 "pubkey": bob_pubkey,
                 "host": format!("127.0.0.1:{port_b}"),
-                "amount": 2_000_000,
-                "push_amount": 1_000_000u64
+                "amount_sats": 2_000_000,
+                "push_amount": 1_000_000_000u64
             }
         }),
     )

--- a/tests/control_open_channel_roundtrip.rs
+++ b/tests/control_open_channel_roundtrip.rs
@@ -193,8 +193,8 @@ async fn control_open_channel_then_list_channels() -> Result<()> {
             "params": {
                 "pubkey": node_b_pubkey,
                 "host": format!("127.0.0.1:{port_b}"),
-                "amount": 2_000_000,
-                "push_amount": 1_000_000u64
+                "amount_sats": 2_000_000,
+                "push_amount": 1_000_000_000u64
             }
         }),
     )

--- a/tests/e2e_blackbox_container.rs
+++ b/tests/e2e_blackbox_container.rs
@@ -1085,8 +1085,8 @@ async fn e2e_control_alice_opens_channel_and_bidirectional_payment() -> Result<(
             "params": {
                 "pubkey": bob.node_id(),
                 "host": format!("127.0.0.1:{bob_listen_port}"),
-                "amount": 2_000_000,
-                "push_amount": 1_000_000u64
+                "amount_sats": 2_000_000,
+                "push_amount": 1_000_000_000u64
             }
         }),
     )

--- a/tests/e2e_blackbox_container.rs
+++ b/tests/e2e_blackbox_container.rs
@@ -49,6 +49,10 @@ fn ensure_image_built() {
         let build = Command::new("docker")
             .args([
                 "build",
+                // Use host networking for the build so apt/cargo deps resolve
+                // reliably on environments where BuildKit's default bridge
+                // returns IPv6 addresses that don't route out.
+                "--network=host",
                 "--build-context",
                 "bip321=../bip321",
                 "-f",

--- a/tests/nwc_list_addresses_roundtrip.rs
+++ b/tests/nwc_list_addresses_roundtrip.rs
@@ -107,7 +107,7 @@ async fn test_nwc_list_addresses_returns_seeded_addresses() -> Result<()> {
                         .find(|a| a.address == "bcrt1qaddr_one")
                         .expect("addr_one not found");
                     assert_eq!(
-                        addr_one.total_received, 80_000,
+                        addr_one.total_received_sats, 80_000,
                         "addr_one should have 50k + 30k = 80k sats"
                     );
 
@@ -117,7 +117,7 @@ async fn test_nwc_list_addresses_returns_seeded_addresses() -> Result<()> {
                         .find(|a| a.address == "bcrt1qaddr_two")
                         .expect("addr_two not found");
                     assert_eq!(
-                        addr_two.total_received, 100_000,
+                        addr_two.total_received_sats, 100_000,
                         "addr_two should have 100k sats"
                     );
 

--- a/tests/nwc_pay_onchain_roundtrip.rs
+++ b/tests/nwc_pay_onchain_roundtrip.rs
@@ -62,7 +62,7 @@ async fn test_nwc_pay_onchain_roundtrip() -> Result<()> {
 
     let params = PayOnchainRequest {
         address: "bcrt1qtest123".to_string(),
-        amount: 50_000,
+        amount_sats: 50_000,
         feerate: None,
     };
     let request_event = Request::pay_onchain(params)


### PR DESCRIPTION
Closes #121.

Two-commit branch cascading [Red-Token/nips](https://github.com/Red-Token/nips) units patch + [dukeh3/nostr#4](https://github.com/dukeh3/nostr/pull/4) (merged) into the service.

## Commit 1 — NIP-XX open_channel (local structs)
- `OpenChannelParams`: `amount` → `amount_sats`
- Handler: drop `* 1000` conversion on `push_amount` — the wire is now msats per spec.
- Tests `control_open_channel_roundtrip`, `control_channel_payments_scenario`, `e2e_blackbox_container` updated to send `amount_sats` + msat `push_amount`.

## Commit 2 — NIP-47 (nwc crate rev bump + field accesses)
- `Cargo.toml`: pin `nostr-sdk` + `nwc` to `247df9c1` (was `9ac9adc2`).
- `PayOnchainRequest.amount` → `.amount_sats` (three call sites).
- `GetBalanceResponse.onchain_balance` → `.onchain_balance_sats`; divide msat total by 1000 for the wire value.
- `AddressTransaction.amount` → `.amount_sats`.
- `LookupAddressResponse.total_received` → `.total_received_sats`.
- `AddressEntry.total_received` → `.total_received_sats`.
- Tests `nwc_pay_onchain_roundtrip`, `nwc_list_addresses_roundtrip` updated.

## Deploy coordination

[dukeh3/ldk-controller-stage-test#3](https://github.com/dukeh3/ldk-controller-stage-test/pull/3) updates `nwc-check` to match. **Merge stage-test PR first** so the deploy+smoke CI pipeline lines up — otherwise the new service ships but nwc-check is still on the old field name and the smoke step fails.

## Verification

- `cargo check --tests` clean on both changes.
- End-to-end verification is the integration-test cascade (task #5) against the redeployed alice+bob.